### PR TITLE
Fix numba dependency on Python 3.12

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -16,9 +16,10 @@ opencv-contrib-python-headless==4.11.0.86
 httpx==0.28.1
 onnxruntime==1.22.0
 timm==1.0.15
-numpy==2.3.0
+numpy==2.2.6
 tokenizers==0.21.1
 packaging==25.0
 rembg==2.0.66
 groundingdino-py==0.4.0
 segment_anything==1.0
+numba==0.61.2


### PR DESCRIPTION
## Summary
- pin numba and numpy versions in requirements

## Testing
- `pip install -r requirements_versions.txt`

------
https://chatgpt.com/codex/tasks/task_e_68530afa2c208333a79f221e0c4963a6