### PR TITLE
Fix gradio import for latest version

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -18,7 +18,7 @@ from gradio_client.serializing import ImgSerializable
 from PIL import Image as _Image  # using _ to minimize namespace pollution
 
 from gradio import processing_utils, utils, Error
-from gradio.components.base import IOComponent, _Keywords, Block
+from gradio.components.base import Component, _Keywords, Block
 from gradio.deprecation import warn_style_method_deprecation
 from gradio.events import (
     Changeable,
@@ -43,7 +43,7 @@ class Image(
     Streamable,
     Selectable,
     Uploadable,
-    IOComponent,
+    Component,
     ImgSerializable,
     TokenInterpretable,
 ):
@@ -158,7 +158,7 @@ class Image(
             if show_share_button is None
             else show_share_button
         )
-        IOComponent.__init__(
+        Component.__init__(
             self,
             label=label,
             every=every,
@@ -192,7 +192,7 @@ class Image(
             "selectable": self.selectable,
             "show_share_button": self.show_share_button,
             "show_download_button": self.show_download_button,
-            **IOComponent.get_config(self),
+            **Component.get_config(self),
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary
- update `gradio_hijack` to use `Component` instead of `IOComponent`

## Testing
- `python -m unittest tests`

------
https://chatgpt.com/codex/tasks/task_e_685316482998833381a1201c732c2faa