### PR TITLE
Fix missing gradio.deprecation import

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -19,7 +19,14 @@ from PIL import Image as _Image  # using _ to minimize namespace pollution
 
 from gradio import processing_utils, utils, Error
 from gradio.components.base import Component, _Keywords, Block
-from gradio.deprecation import warn_style_method_deprecation
+try:
+    from gradio.deprecation import warn_style_method_deprecation
+except Exception:  # pragma: no cover - fallback for older gradio versions
+    def warn_style_method_deprecation() -> None:
+        warnings.warn(
+            "The style() method is deprecated. Please set style arguments in the constructor instead.",
+            DeprecationWarning,
+        )
 from gradio.events import (
     Changeable,
     Clearable,


### PR DESCRIPTION
## Summary
- provide fallback when gradio.deprecation is not present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531748ead08333ab39b7883597d826