### PR TITLE
Fix gradio image api_info

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -19,6 +19,7 @@ from PIL import Image as _Image  # using _ to minimize namespace pollution
 
 from gradio import processing_utils, utils, Error
 from gradio.components.base import Component, _Keywords, Block
+from gradio.data_classes import ImageData
 
 try:
     from gradio.deprecation import warn_style_method_deprecation
@@ -114,6 +115,8 @@ class Image(
     Demos: image_mod, image_mod_default_image
     Guides: image-classification-in-pytorch, image-classification-in-tensorflow, image-classification-with-vision-transformers, building-a-pictionary_app, create-your-own-friends-with-a-gan
     """
+
+    data_model = ImageData
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- fix NotImplementedError when generating Gradio config by importing ImageData and registering the data model

## Testing
- `PYTEST_CURRENT_TEST=1 python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68531f6e56e0833387a595c979d161d0