### PR TITLE
Fix gradio 5.34 compatibility

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -522,6 +522,22 @@ class Image(
             return input_data
         return str(utils.abspath(input_data))
 
+    def example_payload(self) -> Any:
+        """Return example payload using gradio's default Image component."""
+        try:
+            from gradio.components import Image as _GrImage
+            return _GrImage().example_payload()
+        except Exception:
+            return None
+
+    def example_value(self) -> Any:
+        """Return example value using gradio's default Image component."""
+        try:
+            from gradio.components import Image as _GrImage
+            return _GrImage().example_value()
+        except Exception:
+            return None
+
 
 all_components = []
 


### PR DESCRIPTION
## Summary
- add fallback example payload and value implementations to custom gradio image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685322ac634c8333aab8ee9f1d058f59