### PR TITLE
Fix compatibility with gradio 5.x

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -18,6 +18,32 @@ from gradio_client.serializing import ImgSerializable
 from PIL import Image as _Image  # using _ to minimize namespace pollution
 
 from gradio import processing_utils, utils, Error
+
+# -----------------------------------------------------------------------------
+# Compatibility helpers for removed gradio functions
+# -----------------------------------------------------------------------------
+import base64
+from PIL import Image
+
+if not hasattr(processing_utils, "encode_pil_to_base64"):
+    def encode_pil_to_base64(pil_image: Image.Image, format: str = "png") -> str:
+        """Encode a PIL Image to a base64 data URL."""
+        bytes_data = processing_utils.encode_pil_to_bytes(pil_image, format=format)
+        b64 = base64.b64encode(bytes_data).decode("utf-8")
+        return f"data:image/{format};base64,{b64}"
+
+    processing_utils.encode_pil_to_base64 = encode_pil_to_base64  # type: ignore[attr-defined]
+
+if not hasattr(processing_utils, "encode_array_to_base64"):
+    def encode_array_to_base64(arr: np.ndarray, format: str = "png") -> str:
+        """Encode a numpy array to a base64 data URL."""
+        if arr.dtype != np.uint8:
+            arr = np.clip(arr, 0, 255)
+            arr = arr.astype(np.uint8)
+        img = Image.fromarray(arr)
+        return processing_utils.encode_pil_to_base64(img, format=format)
+
+    processing_utils.encode_array_to_base64 = encode_array_to_base64  # type: ignore[attr-defined]
 from gradio.components.base import Component, _Keywords, Block
 from gradio.data_classes import ImageData
 

--- a/webui.py
+++ b/webui.py
@@ -122,7 +122,7 @@ def inpaint_mode_change(mode, inpaint_engine_version):
     if mode == modules.flags.inpaint_option_detail:
         return [
             gr.update(visible=True), gr.update(visible=False, value=[]),
-            gr.Dataset.update(visible=True, samples=modules.config.example_inpaint_prompts),
+            gr.update(visible=True, samples=modules.config.example_inpaint_prompts),
             False, 'None', 0.5, 0.0
         ]
 
@@ -132,13 +132,13 @@ def inpaint_mode_change(mode, inpaint_engine_version):
     if mode == modules.flags.inpaint_option_modify:
         return [
             gr.update(visible=True), gr.update(visible=False, value=[]),
-            gr.Dataset.update(visible=False, samples=modules.config.example_inpaint_prompts),
+            gr.update(visible=False, samples=modules.config.example_inpaint_prompts),
             True, inpaint_engine_version, 1.0, 0.0
         ]
 
     return [
         gr.update(visible=False, value=''), gr.update(visible=True),
-        gr.Dataset.update(visible=False, samples=modules.config.example_inpaint_prompts),
+        gr.update(visible=False, samples=modules.config.example_inpaint_prompts),
         False, inpaint_engine_version, 1.0, 0.618
     ]
 
@@ -323,8 +323,8 @@ with shared.gradio_root:
 
                                 inpaint_mask_model.change(lambda x: [gr.update(visible=x == 'u2net_cloth_seg')] +
                                                                     [gr.update(visible=x == 'sam')] * 2 +
-                                                                    [gr.Dataset.update(visible=x == 'sam',
-                                                                                       samples=modules.config.example_enhance_detection_prompts)],
+                                                                    [gr.update(visible=x == 'sam',
+       samples=modules.config.example_enhance_detection_prompts)],
                                                           inputs=inpaint_mask_model,
                                                           outputs=[inpaint_mask_cloth_category,
                                                                    inpaint_mask_dino_prompt_text,
@@ -531,7 +531,7 @@ with shared.gradio_root:
                         enhance_mask_model.change(
                             lambda x: [gr.update(visible=x == 'u2net_cloth_seg')] +
                                       [gr.update(visible=x == 'sam')] * 2 +
-                                      [gr.Dataset.update(visible=x == 'sam',
+                                      [gr.update(visible=x == 'sam',
                                                          samples=modules.config.example_enhance_detection_prompts)],
                             inputs=enhance_mask_model,
                             outputs=[enhance_mask_cloth_category, enhance_mask_dino_prompt_text, sam_options,


### PR DESCRIPTION
## Summary
- add compatibility helpers for removed encoding functions
- fix calls to Dataset.update by using gr.update instead

## Testing
- `pytest tests/test_extra_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_685327d687908333b2cc56fe71c644d1