### PR TITLE
Fix PIL alias for encode_array_to_base64

### DIFF
--- a/modules/gradio_hijack.py
+++ b/modules/gradio_hijack.py
@@ -40,7 +40,7 @@ if not hasattr(processing_utils, "encode_array_to_base64"):
         if arr.dtype != np.uint8:
             arr = np.clip(arr, 0, 255)
             arr = arr.astype(np.uint8)
-        img = Image.fromarray(arr)
+        img = _Image.fromarray(arr)
         return processing_utils.encode_pil_to_base64(img, format=format)
 
     processing_utils.encode_array_to_base64 = encode_array_to_base64  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- use `_Image.fromarray` to avoid conflict with the `Image` component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853298c27f88333a91e5fc38d147ea5