### PR TITLE
Fix ratio label symbol and mark experimental release

### DIFF
--- a/fooocus_version.py
+++ b/fooocus_version.py
@@ -1,1 +1,1 @@
-version = '2.5.5'
+version = '2.5.5-b1'

--- a/modules/config.py
+++ b/modules/config.py
@@ -768,7 +768,7 @@ def add_ratio(x):
     a, b = x.replace('*', ' ').split(' ')[:2]
     a, b = int(a), int(b)
     g = math.gcd(a, b)
-    return f'{a}×{b} <span style="color: grey;"> \U00002223 {a // g}:{b // g}</span>'
+    return f'{a}×{b} <span style="color: grey;"> | {a // g}:{b // g}</span>'
 
 
 default_aspect_ratio = add_ratio(default_aspect_ratio)

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 Fooocus Revamp is a modern reimagining of the beloved image generator [Fooocus](https://github.com/lllyasviel/Fooocus). The goal remains the same &mdash; deliver stunning AI generated images without the usual sea of sliders or heavy setup steps &mdash; but the engine has been rebuilt with up‑to‑date libraries and a streamlined workflow.
 
+**Version 2.5.5-b1** *(Experimental)*
+
 Created originally by [lllyasviel](https://github.com/lllyasviel/), Fooocus proved that high quality text‑to‑image generation can be simple and offline. This repository continues that work while upgrading the internals to the latest diffusion technology and providing a clean base for further experimentation.
 
 ## Features at a Glance

--- a/update_log.md
+++ b/update_log.md
@@ -1,6 +1,7 @@
-# [2.5.5](https://github.com/lllyasviel/Fooocus/releases/tag/v2.5.5)
+# [2.5.5-b1](https://github.com/lllyasviel/Fooocus/releases/tag/v2.5.5-b1)
 
 * Fix colab inpaint issue by moving an import statement
+* Experimental release - features under active development
 
 # [2.5.4](https://github.com/lllyasviel/Fooocus/releases/tag/v2.5.4)
 


### PR DESCRIPTION
## Summary
- display aspect ratio using `|` instead of `∣`
- bump version to **2.5.5-b1** and mark it experimental in the README
- note experimental status in update log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333b0f358833390633bdf0812868b