### PR TITLE
Update webui for gradio 5

### DIFF
--- a/modules/theme.py
+++ b/modules/theme.py
@@ -1,0 +1,8 @@
+import gradio as gr
+from gradio.themes.utils import colors
+
+# Custom theme tuned for Fooocus Revamp
+FooocusTheme = gr.themes.Soft(
+    primary_hue=colors.blue,
+    secondary_hue=colors.indigo,
+)

--- a/webui.py
+++ b/webui.py
@@ -17,6 +17,7 @@ import args_manager
 import copy
 import launch
 from extras.inpaint_mask import SAMOptions
+from modules.theme import FooocusTheme
 
 from modules.sdxl_styles import legal_style_names
 from modules.private_logger import get_current_html_path
@@ -150,7 +151,7 @@ title = f'Fooocus {fooocus_version.version}'
 if isinstance(args_manager.args.preset, str):
     title += ' ' + args_manager.args.preset
 
-shared.gradio_root = gr.Blocks(title=title).queue()
+shared.gradio_root = gr.Blocks(title=title, theme=FooocusTheme, analytics_enabled=False).queue()
 
 with shared.gradio_root:
     currentTask = gr.State(worker.AsyncTask(args=[]))


### PR DESCRIPTION
## Summary
- add `FooocusTheme` for a consistent Gradio 5 look
- use the custom theme and disable analytics in `Blocks`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685568ec52e8833389430f1f2896412c